### PR TITLE
Fix Agents tab order

### DIFF
--- a/apps/shinkai-desktop/src/pages/agents.tsx
+++ b/apps/shinkai-desktop/src/pages/agents.tsx
@@ -96,9 +96,9 @@ function AgentsPage() {
                       'data-[state=inactive]:text-official-gray-400 data-[state=inactive]:bg-transparent',
                       'focus-visible:outline-hidden',
                     )}
-                    value="explore"
+                    value="my"
                   >
-                    {t('agents.explore')}
+                    {t('agents.myAgents')}
                   </TabsTrigger>
                   <TabsTrigger
                     className={cn(
@@ -107,9 +107,9 @@ function AgentsPage() {
                       'data-[state=inactive]:text-official-gray-400 data-[state=inactive]:bg-transparent',
                       'focus-visible:outline-hidden',
                     )}
-                    value="my"
+                    value="explore"
                   >
-                    {t('agents.myAgents')}
+                    {t('agents.explore')}
                   </TabsTrigger>
                 </TabsList>
               </div>


### PR DESCRIPTION
## Summary
- swap `Explore` and `My Agents` tabs so `My Agents` is on the left

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68521f6aed9c8321b57b12807b139ea3