### PR TITLE
Fix widget persistence across chats

### DIFF
--- a/apps/shinkai-desktop/src/pages/chat/chat-conversation.tsx
+++ b/apps/shinkai-desktop/src/pages/chat/chat-conversation.tsx
@@ -31,6 +31,7 @@ import {
   useWebSocketMessage,
   useWebSocketTools,
 } from '../../components/chat/websocket-message';
+import { useToolsStore } from '../../components/chat/context/tools-context';
 import { useAnalytics } from '../../lib/posthog-provider';
 import { useAuth } from '../../store/auth';
 import { useSettings } from '../../store/settings';
@@ -149,6 +150,14 @@ const ChatConversation = () => {
 
   useWebSocketMessage({ inboxId, enabled: !!inboxId });
   useWebSocketTools({ inboxId, enabled: !!inboxId });
+  const setWidget = useToolsStore((state) => state.setWidget);
+
+  useEffect(() => {
+    setWidget(null);
+    return () => {
+      setWidget(null);
+    };
+  }, [inboxId, setWidget]);
 
   const setSelectedArtifact = useChatStore(
     (state) => state.setSelectedArtifact,


### PR DESCRIPTION
## Summary
- reset payment widget whenever chat changes by clearing widget state on mount/unmount

## Testing
- `npm run lint` in `apps/shinkai-desktop`
- `npx nx test shinkai-desktop`


------
https://chatgpt.com/codex/tasks/task_e_6852567ef5f4832198151a1a951d96bd