### PR TITLE
Add Chat button for installed agents

### DIFF
--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -637,7 +637,27 @@ const AgentCard = ({
                 </Button>
               ) : null}
               {isInstalled && (
-                <RemoveNetworkAgentButton toolRouterKey={agent.toolRouterKey} />
+                <>
+                  <RemoveNetworkAgentButton toolRouterKey={agent.toolRouterKey} />
+                  <Button
+                    variant="outline"
+                    onClick={async () => {
+                      await navigate('/home', {
+                        state: {
+                          selectedTool: {
+                            key: agent.toolRouterKey,
+                            name: agent.name,
+                            description: agent.description,
+                            args: agent.apiData?.network_tool?.input_args,
+                          },
+                        },
+                      });
+                    }}
+                    size="sm"
+                  >
+                    {t('networkAgentsPage.chat')}
+                  </Button>
+                </>
               )}
             </div>
           )}

--- a/libs/shinkai-i18n/locales/en-US.json
+++ b/libs/shinkai-i18n/locales/en-US.json
@@ -1001,6 +1001,7 @@
     "addedDescription": "{{name}} is now in your collection. Start a chat to use it!",
     "browseMore": "Browse More Agents",
     "startChat": "Start Chat",
+    "chat": "Chat",
     "setupRequired": "Setup required to use paid agents",
     "removeSuccess": "Network agent removed successfully",
     "removeFailed": "Failed to remove agent",

--- a/libs/shinkai-i18n/locales/es-ES.json
+++ b/libs/shinkai-i18n/locales/es-ES.json
@@ -620,6 +620,7 @@
     "removeSuccess": "Agente de red eliminado con éxito",
     "searchPlaceholder": "Buscar agentes",
     "setupRequired": "Se requiere configuración para usar agentes de pago",
+    "chat": "Chat",
     "startChat": "Iniciar Chat",
     "titleDecentralized": "Agentes Descentralizados",
     "titleNetwork": "Red",

--- a/libs/shinkai-i18n/locales/id-ID.json
+++ b/libs/shinkai-i18n/locales/id-ID.json
@@ -620,6 +620,7 @@
     "removeSuccess": "Agen jaringan berhasil dihapus",
     "searchPlaceholder": "Cari agen",
     "setupRequired": "Pengaturan diperlukan untuk menggunakan agen berbayar",
+    "chat": "Chat",
     "startChat": "Mulai Obrolan",
     "titleDecentralized": "Agen Terdesentralisasi",
     "titleNetwork": "Jaringan",

--- a/libs/shinkai-i18n/locales/ja-JP.json
+++ b/libs/shinkai-i18n/locales/ja-JP.json
@@ -620,6 +620,7 @@
     "removeSuccess": "ネットワークエージェントが正常に削除されました",
     "searchPlaceholder": "エージェントを検索",
     "setupRequired": "有料エージェントを使用するには設定が必要です",
+    "chat": "チャット",
     "startChat": "チャットを開始",
     "titleDecentralized": "分散型エージェント",
     "titleNetwork": "ネットワーク",

--- a/libs/shinkai-i18n/locales/tr-TR.json
+++ b/libs/shinkai-i18n/locales/tr-TR.json
@@ -620,6 +620,7 @@
     "removeSuccess": "Ağ ajanı başarıyla kaldırıldı",
     "searchPlaceholder": "Ajanları Ara",
     "setupRequired": "Ücretli ajanları kullanmak için kurulum gereklidir",
+    "chat": "Sohbet",
     "startChat": "Sohbeti Başlat",
     "titleDecentralized": "Merkezi Olmayan Ajanlar",
     "titleNetwork": "Ağ",

--- a/libs/shinkai-i18n/locales/zh-CN.json
+++ b/libs/shinkai-i18n/locales/zh-CN.json
@@ -620,6 +620,7 @@
     "removeSuccess": "网络代理成功移除",
     "searchPlaceholder": "搜索代理",
     "setupRequired": "使用付费代理需要设置",
+    "chat": "聊天",
     "startChat": "开始聊天",
     "titleDecentralized": "去中心化代理",
     "titleNetwork": "网络",

--- a/libs/shinkai-i18n/src/lib/default/index.ts
+++ b/libs/shinkai-i18n/src/lib/default/index.ts
@@ -1128,6 +1128,7 @@ export default {
       '{{name}} is now in your collection. Start a chat to use it!',
     browseMore: 'Browse More Agents',
     startChat: 'Start Chat',
+    chat: 'Chat',
     setupRequired: 'Setup required to use paid agents',
     removeSuccess: 'Network agent removed successfully',
     removeFailed: 'Failed to remove agent',


### PR DESCRIPTION
## Summary
- show a **Chat** button on installed network agent cards
- localize new `chat` label in all locales

## Testing
- `npx nx --version`
- `npx nx lint shinkai-desktop` *(fails: environment crashed)*

------
https://chatgpt.com/codex/tasks/task_e_68530df806288321b306ce4e18cf5234