### PR TITLE
Update network tool endpoint

### DIFF
--- a/libs/shinkai-message-ts/src/api/tools/index.ts
+++ b/libs/shinkai-message-ts/src/api/tools/index.ts
@@ -909,7 +909,7 @@ export const addNetworkTool = async (
   payload: AddNetworkToolRequest,
 ) => {
   const response = await httpClient.post(
-    urlJoin(nodeAddress, '/v2/add_shinkai_tool'),
+    urlJoin(nodeAddress, '/v2/add_network_agent'),
     payload,
     {
       headers: { Authorization: `Bearer ${bearerToken}` },


### PR DESCRIPTION
## Summary
- use `/v2/add_network_agent` when adding a network tool

## Testing
- `npx nx test shinkai-desktop`

------
https://chatgpt.com/codex/tasks/task_e_68533bf6dd248321bd68c875cdd7f856