### PR TITLE
Update payment popup labels when wallet missing

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/message-extra.tsx
+++ b/apps/shinkai-desktop/src/components/chat/message-extra.tsx
@@ -80,6 +80,11 @@ function Payment({
 
   const tokenDecimals = token?.decimals;
   const tokenId = token?.asset_id;
+  const hasWallet = data?.wallet_balances?.data?.length > 0;
+  const confirmLabel =
+    data.usage_type?.PerUse === 'Free'
+      ? t('networkAgentsPage.proceedFree')
+      : t('networkAgentsPage.confirmPayment');
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -263,39 +268,43 @@ function Payment({
                 </RadioGroup> */}
                     <div className="bg-official-gray-850 rounded-lg p-4">
                       <h4 className="mb-2 font-medium">
-                        {t('networkAgentsPage.yourWallet')}
+                        {hasWallet
+                          ? t('networkAgentsPage.yourWallet')
+                          : t('networkAgentsPage.noWalletSetup')}
                       </h4>
-                      <div className="flex flex-col gap-2">
-                        <div className="flex items-center justify-between text-sm">
-                          <span className="text-official-gray-400">
-                            {t('networkAgentsPage.walletAddress')}:
-                          </span>
-                          <div className="flex flex-col items-end justify-start gap-2">
-                            {truncateAddress(data.invoice.address.address_id)}
+                      {hasWallet && (
+                        <div className="flex flex-col gap-2">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="text-official-gray-400">
+                              {t('networkAgentsPage.walletAddress')}:
+                            </span>
+                            <div className="flex flex-col items-end justify-start gap-2">
+                              {truncateAddress(data.invoice.address.address_id)}
+                            </div>
+                          </div>
+                          <div className="flex items-start justify-between text-sm">
+                            <span className="text-official-gray-400">
+                              {t('networkAgentsPage.usdcBalance')}:
+                            </span>
+                            <div className="flex flex-col items-end justify-start gap-0.5">
+                              {data.wallet_balances.data.map((balance) => (
+                                <div
+                                  className="text-right"
+                                  key={balance.asset.asset_id}
+                                >
+                                  {formatBalanceAmount(
+                                    balance.amount,
+                                    balance.asset.decimals,
+                                  )}{' '}
+                                  <span className="text-official-gray-200 font-medium">
+                                    {balance.asset.asset_id}
+                                  </span>
+                                </div>
+                              ))}
+                            </div>
                           </div>
                         </div>
-                        <div className="flex items-start justify-between text-sm">
-                          <span className="text-official-gray-400">
-                            {t('networkAgentsPage.usdcBalance')}:
-                          </span>
-                          <div className="flex flex-col items-end justify-start gap-0.5">
-                            {data.wallet_balances.data.map((balance) => (
-                              <div
-                                className="text-right"
-                                key={balance.asset.asset_id}
-                              >
-                                {formatBalanceAmount(
-                                  balance.amount,
-                                  balance.asset.decimals,
-                                )}{' '}
-                                <span className="text-official-gray-200 font-medium">
-                                  {balance.asset.asset_id}
-                                </span>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      </div>
+                      )}
                     </div>
                   </div>
                   <div className="ml-auto flex max-w-xs items-center justify-between gap-2">
@@ -323,7 +332,7 @@ function Payment({
                       }}
                       size="md"
                     >
-                      {t('networkAgentsPage.confirmPayment')}
+                      {confirmLabel}
                     </Button>
                   </div>
                 </motion.div>

--- a/libs/shinkai-i18n/locales/en-US.json
+++ b/libs/shinkai-i18n/locales/en-US.json
@@ -1033,6 +1033,8 @@
     "walletAddress": "Wallet Address",
     "usdcBalance": "USDC Balance",
     "confirmPayment": "Confirm Payment",
+    "proceedFree": "Proceed (Free)",
+    "noWalletSetup": "You don't have a wallet set up yet",
     "processingPayment": "Processing Payment",
     "pleaseWait": "Please wait while we process your transaction...",
     "paymentSuccessful": "Payment Successful!",

--- a/libs/shinkai-i18n/locales/es-ES.json
+++ b/libs/shinkai-i18n/locales/es-ES.json
@@ -605,6 +605,8 @@
     "author": "Autor",
     "browseMore": "Explorar Más Agentes",
     "confirmPayment": "Confirmar Pago",
+    "proceedFree": "Continuar (Gratis)",
+    "noWalletSetup": "Aún no tienes una billetera configurada",
     "connectWallet": "Conectar Billetera",
     "connectWalletDescription": "Conecta tu billetera para pagar por el uso de agentes y recibir ganancias de tus agentes publicados",
     "costPerUse": "Costo por uso",

--- a/libs/shinkai-i18n/locales/id-ID.json
+++ b/libs/shinkai-i18n/locales/id-ID.json
@@ -605,6 +605,8 @@
     "author": "Penulis",
     "browseMore": "Jelajahi Agen Lain",
     "confirmPayment": "Konfirmasi Pembayaran",
+    "proceedFree": "Lanjutkan (Gratis)",
+    "noWalletSetup": "Anda belum memiliki dompet",
     "connectWallet": "Sambungkan Dompet",
     "connectWalletDescription": "Sambungkan dompet Anda untuk membayar penggunaan agen dan menerima penghasilan dari agen yang Anda terbitkan",
     "costPerUse": "Biaya per penggunaan",

--- a/libs/shinkai-i18n/locales/ja-JP.json
+++ b/libs/shinkai-i18n/locales/ja-JP.json
@@ -605,6 +605,8 @@
     "author": "著者",
     "browseMore": "他のエージェントをブラウズ",
     "confirmPayment": "支払いを確認",
+    "proceedFree": "続行（無料）",
+    "noWalletSetup": "まだウォレットが設定されていません",
     "connectWallet": "ウォレットに接続",
     "connectWalletDescription": "エージェントの使用料を支払い、公開したエージェントからの収益を受け取るためにウォレットを接続します",
     "costPerUse": "使用ごとのコスト",

--- a/libs/shinkai-i18n/locales/tr-TR.json
+++ b/libs/shinkai-i18n/locales/tr-TR.json
@@ -605,6 +605,8 @@
     "author": "Yazar",
     "browseMore": "Daha Fazla Ajan Gözat",
     "confirmPayment": "Ödemeyi Onayla",
+    "proceedFree": "Devam Et (Ücretsiz)",
+    "noWalletSetup": "Henüz bir cüzdanınız yok",
     "connectWallet": "Cüzdanı Bağla",
     "connectWalletDescription": "Ajan kullanımını ödemek ve yayınladığınız ajanlardan kazanç almak için cüzdanınızı bağlayın",
     "costPerUse": "Kullanım Başına Maliyet",

--- a/libs/shinkai-i18n/locales/zh-CN.json
+++ b/libs/shinkai-i18n/locales/zh-CN.json
@@ -605,6 +605,8 @@
     "author": "作者",
     "browseMore": "浏览更多代理",
     "confirmPayment": "确认付款",
+    "proceedFree": "继续（免费）",
+    "noWalletSetup": "你还没有设置钱包",
     "connectWallet": "连接钱包",
     "connectWalletDescription": "连接您的钱包以支付代理使用费用并从您发布的代理中获得收益",
     "costPerUse": "每次使用的费用",

--- a/libs/shinkai-i18n/src/lib/default/index.ts
+++ b/libs/shinkai-i18n/src/lib/default/index.ts
@@ -1166,6 +1166,8 @@ export default {
     walletAddress: 'Wallet Address',
     usdcBalance: 'USDC Balance',
     confirmPayment: 'Confirm Payment',
+    proceedFree: 'Proceed (Free)',
+    noWalletSetup: "You don't have a wallet set up yet",
     processingPayment: 'Processing Payment',
     pleaseWait: 'Please wait while we process your transaction...',
     paymentSuccessful: 'Payment Successful!',


### PR DESCRIPTION
## Summary
- add `noWalletSetup` and `proceedFree` translations
- handle missing wallet in Payment popup
- show `Proceed (Free)` for free agents

## Testing
- `npx eslint apps/shinkai-desktop/src/components/chat/message-extra.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6853719ff6a88321b17aa4470cda98e1