### PR TITLE
Make My Agents default tab

### DIFF
--- a/apps/shinkai-desktop/src/pages/agents.tsx
+++ b/apps/shinkai-desktop/src/pages/agents.tsx
@@ -66,7 +66,7 @@ function AgentsPage() {
   });
 
   const { t, Trans } = useTranslation();
-  const [selectedTab, setSelectedTab] = useState<'my' | 'explore'>('explore');
+  const [selectedTab, setSelectedTab] = useState<'my' | 'explore'>('my');
 
   const [searchQuery, setSearchQuery] = useState('');
 


### PR DESCRIPTION
## Summary
- change the default selected tab on the Agents page to show **My Agents** first

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685381a0c3948321aa6d6e56bb9146fa