### PR TITLE
Fix add agent button label

### DIFF
--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -640,7 +640,7 @@ const AgentCard = ({
                           setShowDetailsModal(false);
                         }}
                       >
-                        {t('agentsPage.addAgent')}
+                        {t('networkAgentsPage.nextAddAgent')}
                       </Button>
                     </DialogFooter>
                   )}

--- a/libs/shinkai-i18n/locales/en-US.json
+++ b/libs/shinkai-i18n/locales/en-US.json
@@ -1006,6 +1006,7 @@
     "searchPlaceholder": "Search for agents",
     "toolRouterKey": "Tool Router Key",
     "addAgent": "Add Agent",
+    "nextAddAgent": "Next (Add Agent)",
     "addedSuccess": "Added Successfully!",
     "addedDescription": "{{name}} is now in your collection. Start a chat to use it!",
     "browseMore": "Browse More Agents",

--- a/libs/shinkai-i18n/src/lib/default/index.ts
+++ b/libs/shinkai-i18n/src/lib/default/index.ts
@@ -1132,6 +1132,7 @@ export default {
     searchPlaceholder: 'Search for agents',
     toolRouterKey: 'Tool Router Key',
     addAgent: 'Add Agent',
+    nextAddAgent: 'Next (Add Agent)',
     addedSuccess: 'Added Successfully!',
     addedDescription:
       '{{name}} is now in your collection. Start a chat to use it!',


### PR DESCRIPTION
## Summary
- update wording in network agent details modal
- add i18n entry for "Next (Add Agent)"
- update English locale for new label

## Testing
- `npx nx run-many --target=test`
- `npx nx run-many --target=lint --parallel=1`


------
https://chatgpt.com/codex/tasks/task_e_685392d3714483218383d4872fba31c3