### PR TITLE
Fix Start Chat navigation for new network agents

### DIFF
--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -95,7 +95,6 @@ export const NetworkAgentPage = () => {
     { enabled: !!isWalletConnected },
   );
 
-
   return (
     <Tabs
       className="flex size-full flex-col"
@@ -699,6 +698,7 @@ export const InstallAgentModal = ({
   const isWalletConnected =
     walletInfo?.payment_wallet || walletInfo?.receiving_wallet;
 
+  const [addedAgentId, setAddedAgentId] = useState<string | undefined>();
 
   const { mutateAsync: addNetworkTool, isPending: isAddingAgent } =
     useAddNetworkTool({
@@ -707,7 +707,8 @@ export const InstallAgentModal = ({
           description: error.response?.data?.message ?? error.message,
         });
       },
-      onSuccess: () => {
+      onSuccess: (data) => {
+        setAddedAgentId(data?.agent_id);
         setStep(2);
       },
     });
@@ -795,8 +796,8 @@ export const InstallAgentModal = ({
                           <strong className="text-white">
                             {`${formatBalanceAmount(amount ?? '0', 6)} ${ticker}`}
                           </strong>{' '}
-                          when you use it in chat. You'll see a payment confirmation
-                          before any charges.
+                          when you use it in chat. You'll see a payment
+                          confirmation before any charges.
                         </>
                       )}
                     </p>
@@ -881,12 +882,7 @@ export const InstallAgentModal = ({
                   handleClose();
                   await navigate('/home', {
                     state: {
-                      selectedTool: {
-                        key: agent.toolRouterKey,
-                        name: agent.name,
-                        description: agent.description,
-                        args: agent.apiData?.network_tool?.input_args,
-                      },
+                      agentName: addedAgentId ?? agent.id,
                     },
                   });
                 }}


### PR DESCRIPTION
## Summary
- keep track of the returned `agent_id` when adding a network agent
- when clicking **Start Chat** after adding a network agent, navigate to `/home` with that agent pre-selected

## Testing
- `npx nx format:write`
- `npx nx format:check`


------
https://chatgpt.com/codex/tasks/task_e_68539fe41d1483219fccbbb5223a168f