### PR TITLE
Add Network Tracing button next to tool dropdown

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/components/message.tsx
+++ b/apps/shinkai-desktop/src/components/chat/components/message.tsx
@@ -392,22 +392,33 @@ export const MessageBase = ({
                             key={`${tool.name}-${index}`}
                             value={`${tool.name}-${index}`}
                           >
-                            <AccordionTrigger
-                              className={cn(
-                                'min-w-[10rem] gap-3 py-0 pr-2 no-underline hover:no-underline',
-                                'hover:bg-official-gray-900 [&[data-state=open]]:bg-official-gray-950 transition-colors',
-                                tool.status !== ToolStatusType.Complete &&
-                                  '[&>svg]:hidden',
-                              )}
-                            >
-                              <ToolCard
-                                args={tool.args}
-                                name={tool.name}
-                                status={tool.status ?? ToolStatusType.Complete}
-                                toolRouterKey={tool.toolRouterKey}
-                                onOpenTracing={() => setTracingOpen(true)}
-                              />
-                            </AccordionTrigger>
+                              <div className="flex items-center">
+                                <AccordionTrigger
+                                  className={cn(
+                                    'min-w-[10rem] flex-1 gap-3 py-0 pr-2 no-underline hover:no-underline',
+                                    'hover:bg-official-gray-900 [&[data-state=open]]:bg-official-gray-950 transition-colors',
+                                    tool.status !== ToolStatusType.Complete &&
+                                      '[&>svg]:hidden',
+                                  )}
+                                >
+                                  <ToolCard
+                                    args={tool.args}
+                                    name={tool.name}
+                                    status={tool.status ?? ToolStatusType.Complete}
+                                    toolRouterKey={tool.toolRouterKey}
+                                  />
+                                </AccordionTrigger>
+                                <Button
+                                  variant="outline"
+                                  size="xs"
+                                  className="ml-2 h-6 px-2"
+                                  onClick={() => setTracingOpen(true)}
+                                  onMouseDown={(e) => e.stopPropagation()}
+                                  onKeyDown={(e) => e.stopPropagation()}
+                                >
+                                  Network Tracing
+                                </Button>
+                              </div>
                             <AccordionContent className="bg-official-gray-950 flex flex-col gap-1 rounded-b-lg px-3 pt-2 pb-3 text-xs">
                               {Object.keys(tool.args).length > 0 && (
                                 <span className="font-medium text-white">
@@ -744,13 +755,11 @@ export function ToolCard({
   // args,
   status,
   toolRouterKey,
-  onOpenTracing,
 }: {
   args: ToolArgs;
   status: ToolStatusType;
   name: string;
   toolRouterKey: string;
-  onOpenTracing: () => void;
 }) {
   const { data: networkAgents } = useGetNetworkAgents();
   const { t } = useTranslation();
@@ -806,14 +815,6 @@ export function ToolCard({
             >
               {formatText(name)}
             </Link>
-            <Button
-              variant="outline"
-              size="xs"
-              className="h-6 px-2"
-              onClick={onOpenTracing}
-            >
-              Network Tracing
-            </Button>
           </div>
         </div>
       </motion.div>

--- a/apps/shinkai-desktop/src/components/chat/components/message.tsx
+++ b/apps/shinkai-desktop/src/components/chat/components/message.tsx
@@ -411,7 +411,7 @@ export const MessageBase = ({
                                 <Button
                                   variant="outline"
                                   size="xs"
-                                  className="ml-2 h-6 px-2"
+                                  className="ml-2 mr-2 h-6 px-2"
                                   onClick={() => setTracingOpen(true)}
                                   onMouseDown={(e) => e.stopPropagation()}
                                   onKeyDown={(e) => e.stopPropagation()}

--- a/apps/shinkai-desktop/src/components/chat/components/message.tsx
+++ b/apps/shinkai-desktop/src/components/chat/components/message.tsx
@@ -405,6 +405,7 @@ export const MessageBase = ({
                                 name={tool.name}
                                 status={tool.status ?? ToolStatusType.Complete}
                                 toolRouterKey={tool.toolRouterKey}
+                                onOpenTracing={() => setTracingOpen(true)}
                               />
                             </AccordionTrigger>
                             <AccordionContent className="bg-official-gray-950 flex flex-col gap-1 rounded-b-lg px-3 pt-2 pb-3 text-xs">
@@ -743,11 +744,13 @@ export function ToolCard({
   // args,
   status,
   toolRouterKey,
+  onOpenTracing,
 }: {
   args: ToolArgs;
   status: ToolStatusType;
   name: string;
   toolRouterKey: string;
+  onOpenTracing: () => void;
 }) {
   const { data: networkAgents } = useGetNetworkAgents();
   const { t } = useTranslation();
@@ -803,6 +806,14 @@ export function ToolCard({
             >
               {formatText(name)}
             </Link>
+            <Button
+              variant="outline"
+              size="xs"
+              className="h-6 px-2"
+              onClick={onOpenTracing}
+            >
+              Network Tracing
+            </Button>
           </div>
         </div>
       </motion.div>


### PR DESCRIPTION
## Summary
- add new button to open tracing dialog from tool dropdowns
- support `onOpenTracing` prop in `ToolCard`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854b56b38d083218f9e6090b0d5e27c