### PR TITLE
Fix reasoning dropdown multiline

### DIFF
--- a/apps/shinkai-desktop/src/components/chat/components/message.tsx
+++ b/apps/shinkai-desktop/src/components/chat/components/message.tsx
@@ -896,8 +896,8 @@ export function Reasoning({
             </motion.div>
           </AnimatePresence>
         </AccordionTrigger>
-        <AccordionContent className="bg-official-gray-950 flex flex-col gap-1 rounded-b-lg px-3 pt-2 pb-3 text-sm">
-          <span className="text-official-gray-400 break-words">
+          <AccordionContent className="bg-official-gray-950 flex flex-col gap-1 rounded-b-lg px-3 pt-2 pb-3 text-sm">
+          <span className="text-official-gray-400 whitespace-pre-line break-words">
             {reasoning}
           </span>
         </AccordionContent>

--- a/apps/shinkai-desktop/src/windows/spotlight/components/message.tsx
+++ b/apps/shinkai-desktop/src/windows/spotlight/components/message.tsx
@@ -685,7 +685,7 @@ export function Reasoning({
           </AnimatePresence>
         </AccordionTrigger>
         <AccordionContent className="bg-official-gray-950 flex flex-col gap-1 rounded-b-lg px-3 pt-2 pb-3 text-sm">
-          <span className="text-official-gray-400 break-words">
+          <span className="text-official-gray-400 whitespace-pre-line break-words">
             {reasoning}
           </span>
         </AccordionContent>


### PR DESCRIPTION
## Summary
- preserve newlines in reasoning dropdown text on chat and spotlight windows

## Testing
- `npx nx test shinkai-desktop`
- `npx nx lint shinkai-desktop` *(fails: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68570ffe41108321be2b1a81d484ccca