### PR TITLE
Fix publish agent dialog list

### DIFF
--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -50,9 +50,9 @@ export default function PublishAgentDialog() {
 
   const filtered = useMemo(
     () =>
-      (tools ?? []).filter((t) =>
-        t.name.toLowerCase().includes(search.toLowerCase()),
-      ),
+      (tools ?? [])
+        .filter((t) => t.tool_type === 'Agent')
+        .filter((t) => t.name.toLowerCase().includes(search.toLowerCase())),
     [tools, search],
   );
 


### PR DESCRIPTION
## Summary
- filter tools in the publish agent dialog to only show items of type "Agent"

## Testing
- `npx nx format:check`

------
https://chatgpt.com/codex/tasks/task_e_685c7663a3448321ba708134bf430157