### PR TITLE
Show message when no published agents

### DIFF
--- a/apps/shinkai-desktop/src/pages/network-agents.tsx
+++ b/apps/shinkai-desktop/src/pages/network-agents.tsx
@@ -371,6 +371,7 @@ const DiscoverNetworkAgents = ({
 };
 
 const PublishedAgents = () => {
+  const { t } = useTranslation();
   const auth = useAuth((state) => state.auth);
   const { data } = useGetToolsWithOfferings({
     nodeAddress: auth?.node_address ?? '',
@@ -401,6 +402,17 @@ const PublishedAgents = () => {
       };
     });
   }, [data]);
+
+  if (publishedAgents.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 pt-20">
+        <p className="text-center text-base font-medium">
+          {t('networkAgentsPage.noPublishedAgents')}
+        </p>
+        <PublishAgentDialog />
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/libs/shinkai-i18n/locales/en-US.json
+++ b/libs/shinkai-i18n/locales/en-US.json
@@ -1039,7 +1039,8 @@
     "processingPayment": "Processing Payment",
     "pleaseWait": "Please wait while we process your transaction...",
     "paymentSuccessful": "Payment Successful!",
-    "paymentSuccessfulDescription": "Your payment went through successfully. The tool is now executing..."
+    "paymentSuccessfulDescription": "Your payment went through successfully. The tool is now executing...",
+    "noPublishedAgents": "You haven't shared any agents yet. Publish your agent pressing here."
   },
   "mcpPage": {
     "exposeToolsTab": "Expose Tools",

--- a/libs/shinkai-i18n/locales/es-ES.json
+++ b/libs/shinkai-i18n/locales/es-ES.json
@@ -619,6 +619,7 @@
     "paymentRecipient": "Destinatario del Pago",
     "paymentSuccessful": "¡Pago Exitoso!",
     "paymentSuccessfulDescription": "Tu pago se realizó con éxito. La herramienta se está ejecutando ahora...",
+    "noPublishedAgents": "Aún no has compartido ningún agente. Publica tu agente presionando aquí.",
     "pleaseWait": "Por favor, espera mientras procesamos tu transacción...",
     "processingPayment": "Procesando Pago",
     "publishedTab": "Agentes Publicados",

--- a/libs/shinkai-i18n/locales/id-ID.json
+++ b/libs/shinkai-i18n/locales/id-ID.json
@@ -619,6 +619,7 @@
     "paymentRecipient": "Penerima Pembayaran",
     "paymentSuccessful": "Pembayaran Berhasil!",
     "paymentSuccessfulDescription": "Pembayaran Anda berhasil. Alat sekarang sedang dijalankan...",
+    "noPublishedAgents": "Anda belum membagikan agen apa pun. Publikasikan agen Anda dengan menekan di sini.",
     "pleaseWait": "Silakan tunggu sementara kami memproses transaksi Anda...",
     "processingPayment": "Memproses Pembayaran",
     "publishedTab": "Agen yang Diterbitkan",

--- a/libs/shinkai-i18n/locales/ja-JP.json
+++ b/libs/shinkai-i18n/locales/ja-JP.json
@@ -619,6 +619,7 @@
     "paymentRecipient": "支払い受取人",
     "paymentSuccessful": "支払い成功！",
     "paymentSuccessfulDescription": "支払いが正常に完了しました。ツールが実行中です... ",
+    "noPublishedAgents": "まだエージェントを共有していません。ここを押してあなたのエージェントを公開しましょう。",
     "pleaseWait": "取引を処理していますのでお待ちください...",
     "processingPayment": "支払い処理中",
     "publishedTab": "公開されたエージェント",

--- a/libs/shinkai-i18n/locales/tr-TR.json
+++ b/libs/shinkai-i18n/locales/tr-TR.json
@@ -619,6 +619,7 @@
     "paymentRecipient": "Ödeme Alıcısı",
     "paymentSuccessful": "Ödeme Başarılı!",
     "paymentSuccessfulDescription": "Ödemeniz başarıyla gerçekleşti. Araç şimdi çalışıyor...",
+    "noPublishedAgents": "Henüz hiç ajan paylaşmadınız. Buraya basarak ajanınızı yayınlayın.",
     "pleaseWait": "İşleminizi gerçekleştirirken lütfen bekleyin...",
     "processingPayment": "Ödeme İşleniyor",
     "publishedTab": "Yayınlanan Ajanlar",

--- a/libs/shinkai-i18n/locales/zh-CN.json
+++ b/libs/shinkai-i18n/locales/zh-CN.json
@@ -619,6 +619,7 @@
     "paymentRecipient": "付款接收人",
     "paymentSuccessful": "付款成功！",
     "paymentSuccessfulDescription": "您的付款已成功完成。工具正在执行...",
+    "noPublishedAgents": "你还没有分享任何代理。点击此处发布你的代理。",
     "pleaseWait": "请稍等，我们正在处理您的交易...",
     "processingPayment": "正在处理付款",
     "publishedTab": "已发布代理",

--- a/libs/shinkai-i18n/src/lib/default/index.ts
+++ b/libs/shinkai-i18n/src/lib/default/index.ts
@@ -1174,6 +1174,8 @@ export default {
     paymentSuccessful: 'Payment Successful!',
     paymentSuccessfulDescription:
       'Your payment went through successfully. The tool is now executing...',
+    noPublishedAgents:
+      "You haven't shared any agents yet. Publish your agent pressing here.",
   },
   mcpPage: {
     exposeToolsTab: 'Expose Tools',


### PR DESCRIPTION
## Summary
- display a helpful message when no agents are published
- add `noPublishedAgents` i18n string for all locales

## Testing
- `npx nx format:check`
- `npx nx lint shinkai-desktop`
- `npx nx test shinkai-desktop --maxWorkers=1` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_685c76c346e88321965fb4f76a940dd4