### PR TITLE
Improve agent publish dialog defaults

### DIFF
--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -65,8 +65,8 @@ export default function PublishAgentDialog() {
   const asset = 'USDC';
 
   const { mutateAsync: publish, isPending } = useSetToolOffering({
-    onSuccess: () => {
-      setOpen(false);
+            extra: { name: asset, version: '2' },
+      Downloadable: 'Free',
       setSelected(null);
       setPayTo('');
       setAmount('');

--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -65,15 +65,16 @@ export default function PublishAgentDialog() {
   const asset = 'USDC';
 
   const { mutateAsync: publish, isPending } = useSetToolOffering({
-            extra: { name: asset, version: '2' },
-      Downloadable: 'Free',
+    onSuccess: () => {
       setSelected(null);
       setPayTo('');
       setAmount('');
       setDescription('');
+      setOpen(false);
     },
   });
 
+  useEffect(() => {
     if (selected && walletInfo?.payment_wallet?.data?.address?.address_id) {
       setPayTo(walletInfo.payment_wallet.data.address.address_id);
     }
@@ -99,7 +100,6 @@ export default function PublishAgentDialog() {
           },
         ],
       },
-      Downloadable: { Payment: [] },
     };
 
     if (!selected.tools.length) return;
@@ -111,12 +111,6 @@ export default function PublishAgentDialog() {
 
     await publish({
       nodeAddress: auth?.node_address ?? '',
-              <p className="text-official-gray-400 text-sm">
-                {t('agents.publishDialog.amountHelper')}
-              </p>
-              <p className="text-official-gray-400 text-sm">
-                {t('agents.publishDialog.descriptionHelper')}
-              </p>
       token: auth?.api_v2_key ?? '',
       offering,
     });

--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -74,6 +74,12 @@ export default function PublishAgentDialog() {
     },
   });
 
+  const formatUSDCAmount = (rawAmount: string): string => {
+    if (!rawAmount || isNaN(Number(rawAmount))) return '0.000000';
+    const usdcAmount = Number(rawAmount) / 1000000;
+    return usdcAmount.toFixed(6);
+  };
+
   useEffect(() => {
     if (selected && walletInfo?.payment_wallet?.data?.address?.address_id) {
       setPayTo(walletInfo.payment_wallet.data.address.address_id);
@@ -132,24 +138,42 @@ export default function PublishAgentDialog() {
               </DialogTitle>
             </DialogHeader>
             <div className="mt-4 space-y-2">
-              <Input
-                placeholder={t('agents.publishDialog.paymentAddress')}
-                value={payTo}
-                disabled
-                readOnly
-              />
-              <Input
-                placeholder={t('agents.publishDialog.amount')}
-                value={amount}
-                onChange={(e) => setAmount(e.target.value)}
-              />
-              <Textarea
-                placeholder={t('agents.publishDialog.description')}
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                resize="vertical"
-                className="!min-h-[100px]"
-              />
+              <div>
+                <label className="text-sm font-medium text-white mb-1 block">
+                  Payment Address
+                </label>
+                <Input
+                  placeholder={t('agents.publishDialog.paymentAddress')}
+                  value={payTo}
+                  disabled
+                  readOnly
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-white mb-1 block">
+                  Amount (USDC units per use)
+                </label>
+                <Input
+                  placeholder={t('agents.publishDialog.amount')}
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                />
+                <p className="text-xs text-gray-100 mt-1">
+                  = {formatUSDCAmount(amount)} USDC
+                </p>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-white mb-1 block">
+                  Agent description that will be shown to users
+                </label>
+                <Textarea
+                  placeholder={t('agents.publishDialog.description')}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  resize="vertical"
+                  className="!min-h-[100px]"
+                />
+              </div>
             </div>
             <DialogFooter className="mt-4 flex justify-end gap-2">
               <Button variant="secondary" onClick={() => setSelected(null)}>

--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -112,6 +112,12 @@ export default function PublishAgentDialog() {
 
     await publish({
       nodeAddress: auth?.node_address ?? '',
+              <p className="text-official-gray-400 text-sm">
+                {t('agents.publishDialog.amountHelper')}
+              </p>
+              <p className="text-official-gray-400 text-sm">
+                {t('agents.publishDialog.descriptionHelper')}
+              </p>
       token: auth?.api_v2_key ?? '',
       offering,
     });

--- a/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
+++ b/apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx
@@ -74,7 +74,6 @@ export default function PublishAgentDialog() {
     },
   });
 
-  useEffect(() => {
     if (selected && walletInfo?.payment_wallet?.data?.address?.address_id) {
       setPayTo(walletInfo.payment_wallet.data.address.address_id);
     }

--- a/libs/shinkai-i18n/locales/en-US.json
+++ b/libs/shinkai-i18n/locales/en-US.json
@@ -970,6 +970,8 @@
       "asset": "Asset",
       "amount": "Amount",
       "description": "Description",
+      "amountHelper": "Value in USDC",
+      "descriptionHelper": "Shown to other users when searching for this agent.",
       "selectAgent": "Select Agent",
       "searchAgents": "Search agents",
       "publish": "Publish",

--- a/libs/shinkai-i18n/locales/es-ES.json
+++ b/libs/shinkai-i18n/locales/es-ES.json
@@ -80,6 +80,8 @@
       "amount": "Cantidad",
       "asset": "Activo",
       "description": "Descripción",
+      "amountHelper": "Valor en USDC",
+      "descriptionHelper": "Este texto se mostrará a otros usuarios cuando busquen este agente.",
       "open": "Publicar Agente",
       "paymentAddress": "Dirección de Pago",
       "publish": "Publicar",

--- a/libs/shinkai-i18n/locales/id-ID.json
+++ b/libs/shinkai-i18n/locales/id-ID.json
@@ -80,6 +80,8 @@
       "amount": "Jumlah",
       "asset": "Aset",
       "description": "Deskripsi",
+      "amountHelper": "Nilai dalam USDC",
+      "descriptionHelper": "Teks ini akan ditampilkan kepada pengguna lain saat mereka mencari agen ini.",
       "open": "Terbitkan Agen",
       "paymentAddress": "Alamat Pembayaran",
       "publish": "Terbitkan",

--- a/libs/shinkai-i18n/locales/ja-JP.json
+++ b/libs/shinkai-i18n/locales/ja-JP.json
@@ -80,6 +80,8 @@
       "amount": "金額",
       "asset": "資産",
       "description": "説明",
+      "amountHelper": "金額はUSDCです",
+      "descriptionHelper": "この説明は他のユーザーがこのエージェントを探す際に表示されます。",
       "open": "エージェントを公開",
       "paymentAddress": "支払いアドレス",
       "publish": "公開",

--- a/libs/shinkai-i18n/locales/tr-TR.json
+++ b/libs/shinkai-i18n/locales/tr-TR.json
@@ -80,6 +80,8 @@
       "amount": "Miktar",
       "asset": "Varlık",
       "description": "Açıklama",
+      "amountHelper": "Değer USDC cinsindendir",
+      "descriptionHelper": "Diğer kullanıcılar bu ajanı aradığında bu açıklama gösterilecektir.",
       "open": "Ajanı Yayınla",
       "paymentAddress": "Ödeme Adresi",
       "publish": "Yayınla",

--- a/libs/shinkai-i18n/locales/zh-CN.json
+++ b/libs/shinkai-i18n/locales/zh-CN.json
@@ -80,6 +80,8 @@
       "amount": "金额",
       "asset": "资产",
       "description": "描述",
+      "amountHelper": "金额以 USDC 为单位",
+      "descriptionHelper": "当其他用户搜索该代理时会显示此说明。",
       "open": "发布代理",
       "paymentAddress": "支付地址",
       "publish": "发布",

--- a/libs/shinkai-message-ts/src/api/tools/types.ts
+++ b/libs/shinkai-message-ts/src/api/tools/types.ts
@@ -277,7 +277,7 @@ export type ToolPrice =
 
 export type ToolUsageType = {
   PerUse: ToolPrice;
-  Downloadable: ToolPrice;
+  // Downloadable: ToolPrice; // TODO: add this back in when backend is ready
 };
 export type PaymentTool = {
   toolKey: string;


### PR DESCRIPTION
## Summary
- auto-populate payment address from wallet
- default asset to USDC and remove asset input
- allow multiline description with Textarea

## Testing
- `npx prettier -w apps/shinkai-desktop/src/components/agent/publish-agent-dialog.tsx`
- `npx nx lint shinkai-desktop` *(fails: terminated)*/
- `npx nx test shinkai-desktop` *(fails: terminated)*/

------
https://chatgpt.com/codex/tasks/task_e_685cb577531083218e9c70b4389d5197